### PR TITLE
change api key to personal access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ In order to use this add-on, you need a domain name registered at Gandi.net and 
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
+
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fbenlbrm%2Fhome-assistant-addons)

--- a/gandiDns/CHANGELOG.md
+++ b/gandiDns/CHANGELOG.md
@@ -3,3 +3,6 @@ Frist release version
 
 ## 0.0.2
 Updating documentation
+
+## 0.0.3
+Apikey is deprecated, change it to use PAT instead. See [here](https://api.gandi.net/docs/authentication/).

--- a/gandiDns/DOCS.md
+++ b/gandiDns/DOCS.md
@@ -11,16 +11,22 @@ Follow these steps to get the add-on installed on your system:
 ## How to use
 
 ```yaml
-api_key: GANDI_API_KEY
+token: GANDI_PERSONAL_ACCESS_TOKEN
 domain: my-awesome-domain.rocks
 reccords:
   - sub1
   - sub2
 ```
+
 With this configuration, the add-on will update `sub1.my-awesome-domain.rocks` and `sub2.my-awesome-domain.rocks` dns reccords for your domain zone on your Gandi account. If you just want to update `my-awesome-domain.rocks` add `@` as reccord.
 
+The personal access token can created [here](https://admin.gandi.net/organizations/account/pat). When creating it make sure the following permissions are set :
+
+- See and renew domain names
+- Manage domain name technical configurations
+
 ## Actual limitation !
+
 Be careful, this add-on is using V5 gandi API and the function https://api.gandi.net/docs/livedns/#v5-livedns-domains-fqdn-records-rrset_name when updating a record, the api, remove ALL entries for this record in the DNS zone file. Eg: In your @ record, you can have MX records configured. Updating A record will erase MX records.
 
 This add-on is not compatible with ipv6 and is theoriticaly useless for ipv6.
-

--- a/gandiDns/build.json
+++ b/gandiDns/build.json
@@ -1,11 +1,11 @@
 {
   "squash": false,
   "build_from": {
-    "aarch64": "hassioaddons/base-aarch64:7.0.3",
-    "amd64": "hassioaddons/base-amd64:7.0.3",
-    "armhf": "hassioaddons/base-armhf:7.0.3",
-    "armv7": "hassioaddons/base-armv7:7.0.3",
-    "i386": "hassioaddons/base-i386:7.0.3"
+    "aarch64": "hassioaddons/base-aarch64:16.2.1",
+    "amd64": "hassioaddons/base-amd64:16.2.1",
+    "armhf": "hassioaddons/base-armhf:16.2.1",
+    "armv7": "hassioaddons/base-armv7:16.2.1",
+    "i386": "hassioaddons/base-i386:16.2.1"
   },
   "args": {}
 }

--- a/gandiDns/config.json
+++ b/gandiDns/config.json
@@ -1,6 +1,6 @@
 {
   "name": "GandiDNS",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "slug": "gandi-dns",
   "description": "Update Gandi dns zone",
   "url": "https://github.com/benlbrm/home-assistant-addons/",
@@ -13,7 +13,7 @@
     "reccords": []
   },
   "schema": {
-    "api_key": "str",
+    "token": "str",
     "domain": "str",
     "reccords": ["str"]
   }

--- a/gandiDns/config.json
+++ b/gandiDns/config.json
@@ -8,7 +8,7 @@
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "boot": "auto",
   "options": {
-    "api_key": "",
+    "token": "",
     "domain": "",
     "reccords": []
   },

--- a/gandiDns/rootfs/usr/bin/updater.sh
+++ b/gandiDns/rootfs/usr/bin/updater.sh
@@ -13,20 +13,20 @@ get_current_ip() {
 get_gandi_ip() {
     domain=$1
     reccord=$2
-    api_key=$3
+    token=$3
     
     bashio::log.debug "[Gandi] - Get data for - ${domain} - ${reccord}"
-    echo "$(curl -s -H "Authorization: Apikey ${api_key}" https://api.gandi.net/v5/livedns/domains/${domain}/records/${reccord} | jq -r '.[].rrset_values[0]')"
+    echo "$(curl -s -H "Authorization: Bearer ${token}" https://api.gandi.net/v5/livedns/domains/${domain}/records/${reccord} | jq -r '.[].rrset_values[0]')"
 }
 
 update_gandi_ip() {
     domain=$1
     reccord=$2
-    api_key=$3
+    token=$3
     ip=$4
     payload='{"items": [{"rrset_type": "A","rrset_values": ["'"${ip}"'"],"rrset_ttl": 300}]}'
     bashio::log.debug "[Gandi] - Update reccord - ${domain} - ${reccord}"
-    echo "$(curl -s -g -X PUT -H "Content-Type: application/json" -d "${payload}" -H "Authorization: Apikey ${api_key}" https://api.gandi.net/v5/livedns/domains/${domain}/records/${reccord})"
+    echo "$(curl -s -g -X PUT -H "Content-Type: application/json" -d "${payload}" -H "Authorization: Bearer ${token}" https://api.gandi.net/v5/livedns/domains/${domain}/records/${reccord})"
 
 }
 # ==============================================================================
@@ -35,14 +35,14 @@ update_gandi_ip() {
 main() {
     local domain
     local reccords
-    local api_key
+    local token
     local current_ip
     local gandi_ip
 
 
     domain=$(bashio::config 'domain')
     reccords=$(bashio::config 'reccords')
-    api_key=$(bashio::config 'api_key')
+    token=$(bashio::config 'token')
 
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::log.info "Updater Started"
@@ -50,7 +50,7 @@ main() {
         current_ip=$(get_current_ip)
         bashio::log.debug "Current ip is ${current_ip}"
 
-        gandi_ip=$(get_gandi_ip "${domain}" "${reccords[0]}" "${api_key}")
+        gandi_ip=$(get_gandi_ip "${domain}" "${reccords[0]}" "${token}")
         bashio::log.debug "Gandi ip is ${gandi_ip}"
 
         if [ "${current_ip}" = "${gandi_ip}" ]; then
@@ -61,7 +61,7 @@ main() {
             for reccord in ${reccords}
             do
                 bashio::log.debug "Updating reccord ${reccord}"
-                res=$(update_gandi_ip "${domain}" "${reccord}" "${api_key}" "${current_ip}")
+                res=$(update_gandi_ip "${domain}" "${reccord}" "${token}" "${current_ip}")
                 bashio::log.debug "Reccord ${res}"
                 bashio::log.info "[GandiDns] - Domain ${reccord}.${domain} updated with IP ${current_ip}"
             done

--- a/gandiDns/rootfs/usr/bin/updater.sh
+++ b/gandiDns/rootfs/usr/bin/updater.sh
@@ -16,7 +16,7 @@ get_gandi_ip() {
     token=$3
     
     bashio::log.debug "[Gandi] - Get data for - ${domain} - ${reccord}"
-    echo "$(curl -s -H "Authorization: Bearer ${token}" https://api.gandi.net/v5/livedns/domains/${domain}/records/${reccord} | jq -r '.[].rrset_values[0]')"
+    echo "$(curl -s -H "Authorization: Bearer ${token}" https://api.gandi.net/v5/livedns/domains/${domain}/records/${reccord} | jq -r 'try .[].rrset_values[0] catch "Invalid response"')"
 }
 
 update_gandi_ip() {
@@ -53,9 +53,10 @@ main() {
         gandi_ip=$(get_gandi_ip "${domain}" "${reccords[0]}" "${token}")
         bashio::log.debug "Gandi ip is ${gandi_ip}"
 
-        if [ "${current_ip}" = "${gandi_ip}" ]; then
-            bashio::log.debug "IP's are correct"
-            sleep 600
+        if [ "${gandi_ip} = 'Invalid response'"]; then
+            bashio::log.error "Could not get response from API, make sure your PAT is working"
+        elif [ "${current_ip}" = "${gandi_ip}" ]; then
+            bashio::log.debug "Ip is correct"
         else
             bashio::log.debug "Ip did not match, need an update"
             for reccord in ${reccords}


### PR DESCRIPTION
Hey,

thanks for your plugin !

Just tested it, but the api-key is deprecated so I figured we could change it to the PAT.

I also added a bit more information about the token in the docs.