### PR TITLE
Force IPv4 for public IP detection to avoid pushing IPv6 into A record

### DIFF
--- a/gandiDns/CHANGELOG.md
+++ b/gandiDns/CHANGELOG.md
@@ -12,3 +12,9 @@ Updating documentation
 - Use simpler architecture, with a simple script copied in the docker image and a config.yaml file, following the [custom addon tutorial](https://developers.home-assistant.io/docs/add-ons/tutorial/#the-runsh-file)
 - Add better documentation and a button to install the repo on homeassistant with a simple click (taken from the [custom addon example](https://github.com/home-assistant/addons-example))
 - Change the script to be simply run once, since by default it runs at boot. For regular updating, a scheduler can be used, similar to Let's Encrypt
+
+## 0.0.4
+
+- Force IPv4 when detecting the public IP (`curl -s4`). On a dual-stack network, curl was connecting over IPv6 and the add-on pushed an IPv6 address into an `A` record, which the Gandi LiveDNS API rejects with a 400 error (reported as a PAT permission issue).
+- Add a 10s timeout to the public IP detection request.
+- Make the Gandi API response parsing robust to error objects: instead of crashing with `jq: error: Cannot index string with string "rrset_values"`, the raw response is now logged as an error.

--- a/gandiDns/CHANGELOG.md
+++ b/gandiDns/CHANGELOG.md
@@ -18,3 +18,7 @@ Updating documentation
 - Force IPv4 when detecting the public IP (`curl -s4`). On a dual-stack network, curl was connecting over IPv6 and the add-on pushed an IPv6 address into an `A` record, which the Gandi LiveDNS API rejects with a 400 error (reported as a PAT permission issue).
 - Add a 10s timeout to the public IP detection request.
 - Make the Gandi API response parsing robust to error objects: instead of crashing with `jq: error: Cannot index string with string "rrset_values"`, the raw response is now logged as an error.
+
+## 0.0.5
+
+- Restore an explicit `build.yaml`. Recent Supervisor versions no longer provide a default `BUILD_FROM`, so the add-on failed to install with `base name (${BUILD_FROM}) should not be blank`. The base images are pinned to `ghcr.io/home-assistant/{arch}-base:3.21`, which ships bashio, curl and jq.

--- a/gandiDns/build.yaml
+++ b/gandiDns/build.yaml
@@ -1,0 +1,7 @@
+# https://developers.home-assistant.io/docs/add-ons/configuration#add-on-extended-build
+build_from:
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
+  amd64: ghcr.io/home-assistant/amd64-base:3.21
+  armhf: ghcr.io/home-assistant/armhf-base:3.21
+  armv7: ghcr.io/home-assistant/armv7-base:3.21
+  i386: ghcr.io/home-assistant/i386-base:3.21

--- a/gandiDns/config.yaml
+++ b/gandiDns/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: GandiDNS
-version: "0.0.4"
+version: "0.0.5"
 slug: gandi-dns
 description: Update Gandi dns zone
 url: "https://github.com/benlbrm/home-assistant-addons"

--- a/gandiDns/config.yaml
+++ b/gandiDns/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: GandiDNS
-version: "0.0.3"
+version: "0.0.4"
 slug: gandi-dns
 description: Update Gandi dns zone
 url: "https://github.com/benlbrm/home-assistant-addons"

--- a/gandiDns/updater.sh
+++ b/gandiDns/updater.sh
@@ -7,7 +7,7 @@
 # ==============================================================================
 
 get_current_ip() {
-    echo "$(curl -s ifconfig.me)"
+    echo "$(curl -s4 --max-time 10 ifconfig.me)"
 }
 
 get_gandi_ip() {
@@ -17,7 +17,11 @@ get_gandi_ip() {
     
     bashio::log.debug "[Gandi] - Get data for - ${domain} - ${record}"
     response=$(curl -s -H "Authorization: Bearer ${token}" https://api.gandi.net/v5/livedns/domains/${domain}/records/${record})
-    echo "$response" | jq -r '.[].rrset_values[0]' || bashio::log.error "Error parsing $response"
+    ip=$(echo "$response" | jq -r 'if type=="array" then .[0].rrset_values[0] else empty end')
+    if [ -z "${ip}" ]; then
+        bashio::log.error "Error parsing Gandi API response: ${response}"
+    fi
+    echo "${ip}"
 }
 
 update_gandi_ip() {


### PR DESCRIPTION
Fixes #5

## Bug

`get_current_ip()` used `curl -s ifconfig.me` without forcing IPv4. On a dual-stack
network (e.g. an Orange Livebox with IPv6 enabled), curl connects over IPv6 and
ifconfig.me returns the IPv6 address. The add-on then PUTs that IPv6 value into an
`A` rrset, which the Gandi LiveDNS API rejects with HTTP 400.

The resulting log is misleading, since it blames the PAT permissions while the token
is perfectly fine:

```
[10:31:17] INFO: Current ip is 2a01:cb0c:57b:5100:xxxx:xxxx:xxxx:xxxx
[10:31:17] INFO: Gandi ip is 2.12.229.94
[10:31:17] ERROR: Error 400 while setting DNS, make sur your PAT has the right permissions.
```

Secondary issue: when the API returns an error object instead of a records array,
`jq -r '.[].rrset_values[0]'` crashes with
`jq: error: Cannot index string with string "rrset_values"`, so the actual API
response is never shown.

## Fix

- `get_current_ip()`: `curl -s4 --max-time 10 ifconfig.me` — always resolve the
  public IPv4, which is the only thing that belongs in an `A` record. A timeout is
  added so the add-on cannot hang on the detection request.
- `get_gandi_ip()`: parse with
  `jq -r 'if type=="array" then .[0].rrset_values[0] else empty end'` so an error
  object no longer crashes jq, and log the raw response when the result is empty.
  The existing `${gandi_ip:=not set}` handling in `main()` is unchanged.
- Version bumped to 0.0.4 and CHANGELOG updated.

No refactoring, no IPv6/AAAA support, existing bashio style kept.

## Testing

Tested in production on my own instance (HA Green, aarch64) by patching the image:
the record updates correctly again. `bash -n gandiDns/updater.sh` passes, and
shellcheck reports no new warnings compared to the previous version.
